### PR TITLE
Added support to filter autocomplete results based on place type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Here is the example on how to use it inside your Vue component.
   />
 </template>
 
+
+
 <script setup lang="ts">
 import { ref } from 'vue'
 import { GoogleAutocomplete } from 'vue3-google-autocomplete'
@@ -34,6 +36,20 @@ const value = ref()
 </script>
 
 ```
+
+Pass in types to filter your autocomplete results to your specific Google place type(s).
+[Google Place Types](https://developers.google.com/maps/documentation/places/web-service/supported_types/)
+
+```Javascript
+<template>
+  <GoogleAutocomplete
+    v-model="value"
+    api-key="process.env.VITE_APP_GAPI_KEY"
+    types="['establishment']"
+  />
+</template>
+```
+
 Here on `@set` event you can get your google places api payload
 ```Javascript
 <template>

--- a/src/components/GoogleAutocomplete.vue
+++ b/src/components/GoogleAutocomplete.vue
@@ -24,6 +24,10 @@ const props = defineProps({
     type: String,
     default: ''
   },
+  types: {
+    type: Array,
+    default: () => [],
+  },
   isFullPayload: {
     type: Boolean,
     default: false
@@ -70,6 +74,7 @@ const setPlacesListener = () => {
     const places = google.maps.places
     const autocompleteInstance = new places.Autocomplete(origin.value, {
       fields: ['formatted_address', 'address_components', 'geometry', 'name'],
+      types: props.types,
       strictBounds: false
     })
 


### PR DESCRIPTION
Pass in types to filter your autocomplete results.

i.e types="['establishment']" will only return businesses.

![Screenshot 2024-09-27 at 9 26 16 PM](https://github.com/user-attachments/assets/64def0a1-09ef-49b3-9150-59ace3febb21)
